### PR TITLE
perf(module): set a timeout on commit HTTP calls

### DIFF
--- a/module/commit.py
+++ b/module/commit.py
@@ -133,7 +133,7 @@ def proceed() -> None:
     logging.info("get event data from github: name jojoee, start")
     target_api = "https://api.github.com/users/jojoee/events?per_page=100"
     requests_auth = (GITHUB_USER, GITHUB_TOKEN)
-    events = requests.get(target_api, auth=requests_auth).json()
+    events = requests.get(target_api, auth=requests_auth, timeout=10.0).json()
     logging.debug("get event data from github: name jojoee, finish, %s", events)
 
     # validate API response is a list
@@ -162,7 +162,7 @@ def proceed() -> None:
 
         time.sleep(0.2)  # rate limit
         requests_auth = (GITHUB_USER, GITHUB_TOKEN)
-        compare_res = requests.get(compare_url, auth=requests_auth).json()
+        compare_res = requests.get(compare_url, auth=requests_auth, timeout=10.0).json()
 
         if not isinstance(compare_res, dict):
             logging.warning("Invalid compare response: %s", compare_res)

--- a/module/image.py
+++ b/module/image.py
@@ -110,7 +110,7 @@ def remove_old_gif_files():
     )
 
 
-def remove_old_files(dir_path: str = IMAGE_DIR_PATH, n_seconds: int = 5 * 60, keep_file_names_key: Dict[str, int] = {}):
+def remove_old_files(dir_path: str = IMAGE_DIR_PATH, n_seconds: int = 5 * 60, keep_file_names_key: Dict[str, int] = None):
     """
 
     :param dir_path: directory of files
@@ -118,6 +118,8 @@ def remove_old_files(dir_path: str = IMAGE_DIR_PATH, n_seconds: int = 5 * 60, ke
     :param keep_file_names_key: e.g. {".gitkeep": 1}
     :return:
     """
+    if keep_file_names_key is None:
+        keep_file_names_key = {}
     now = time.time()
     n_files = 0
     time_str = str(timedelta(seconds=n_seconds))


### PR DESCRIPTION
I ran into this while reading through the code path around module/commit.py. Set a timeout on commit HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.

Backward-compat note: This changes a public function signature by replacing mutable defaults with None guards. Call sites stay source-compatible, but callers introspecting defaults will see None now.